### PR TITLE
feat(examples/order): add order processing example

### DIFF
--- a/examples/order/README.md
+++ b/examples/order/README.md
@@ -1,0 +1,56 @@
+# Order Processing Example
+
+The example models a simplified order processing system.  The states are
+`OrderCreated`, `OrderPaid`, `OrderShipped`, `OrderDelivered`, and
+`OrderCancelled`.
+
+## HTTP Endpoints:
+
+`/order`: Returns the current order information as JSON.
+`/transition`: Transitions the order to a new state based on the request body (e.g., `{"to": "paid"}`).
+
+## Look at it in action
+
+Get Order:
+
+```Bash
+curl http://localhost:8080/order
+```
+
+Pay for Order:
+
+```Bash
+curl -X POST -H "Content-Type: application/json" -d '{"to": "paid"}' \
+http://localhost:8080/transition
+```
+
+Ship Order:
+
+```Bash
+curl -X POST -H "Content-Type: application/json" -d '{"to": "shipped"}' \
+http://localhost:8080/transition
+```
+
+Deliver Order:
+
+```Bash
+curl -X POST -H "Content-Type: application/json" -d '{"to": "delivered"}' \
+http://localhost:8080/transition
+```
+
+Cancel Order (from Created):
+
+```Bash
+curl -X POST -H "Content-Type: application/json" -d '{"to": "cancelled"}' \
+http://localhost:8080/transition
+```
+
+Cancel Order (from Paid):
+
+```Bash
+curl -X POST -H "Content-Type: application/json" -d '{"to": "cancelled"}' \
+http://localhost:8080/transition
+```
+
+ Each transition will print a message to the server's console, and the `/order`
+ endpoint will reflect the updated status.

--- a/examples/order/order_example.go
+++ b/examples/order/order_example.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/eliseomartelli/micromachine"
+)
+
+type OrderState string
+
+const (
+	OrderCreated   OrderState = "created"
+	OrderPaid      OrderState = "paid"
+	OrderShipped   OrderState = "shipped"
+	OrderDelivered OrderState = "delivered"
+	OrderCancelled OrderState = "cancelled"
+)
+
+type Order struct {
+	mu             sync.Mutex
+	ID             int        `json:"id"`
+	Status         OrderState `json:"status"`
+	Items          []string   `json:"items"`
+	TrackingNumber string     `json:"tracking_number"`
+}
+
+func orderProcessingExample() {
+	order := &Order{
+		ID:     123,
+		Items:  []string{"Product A", "Product B"},
+		Status: OrderCreated,
+	}
+
+	machine := micromachine.NewMicromachine(order.Status)
+
+	machine.AddTransition(OrderCreated, OrderPaid, func() error {
+		order.mu.Lock()
+		defer order.mu.Unlock()
+		fmt.Println("Order paid. Processing payment...")
+		order.Status = OrderPaid
+		return nil
+	})
+
+	machine.AddTransition(OrderPaid, OrderShipped, func() error {
+		order.mu.Lock()
+		defer order.mu.Unlock()
+		fmt.Println("Order shipped. Generating tracking number...")
+		order.Status = OrderShipped
+		order.TrackingNumber = "ABC123XYZ"
+		return nil
+	})
+
+	machine.AddTransition(OrderShipped, OrderDelivered, func() error {
+		order.mu.Lock()
+		defer order.mu.Unlock()
+		fmt.Println("Order delivered. Updating inventory...")
+		order.Status = OrderDelivered
+		return nil
+	})
+
+	machine.AddTransition(OrderCreated, OrderCancelled, func() error {
+		order.mu.Lock()
+		defer order.mu.Unlock()
+		fmt.Println("Order cancelled.")
+		order.Status = OrderCancelled
+		return nil
+	})
+
+	machine.AddTransition(OrderPaid, OrderCancelled, func() error {
+		order.mu.Lock()
+		defer order.mu.Unlock()
+		fmt.Println("Order cancelled.")
+		order.Status = OrderCancelled
+		return nil
+	})
+
+	http.HandleFunc("/order", func(w http.ResponseWriter, r *http.Request) {
+		order.mu.Lock()
+		defer order.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(order)
+	})
+
+	http.HandleFunc("/transition", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			To OrderState `json:"to"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := machine.Transition(req.To); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	fmt.Println("listening on port 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+
+}
+
+func main() {
+	orderProcessingExample()
+}


### PR DESCRIPTION
- Added a new directory `examples/order` containing a simple order
  processing system.
- Implemented HTTP endpoints `/order` and `/transition` to manage the
  order lifecycle.
- Used `micromachine` for state management of the order.
- Included a README.md file with instructions on how to use the example.
