### PR TITLE
feat: add method to retrieve valid transitions

### DIFF
--- a/statemachine.go
+++ b/statemachine.go
@@ -70,3 +70,16 @@ func (sm *Micromachine[T]) State() T {
 	defer sm.mu.Unlock()
 	return sm.state
 }
+
+// ValidTransitions returns a slice of valid states that can be transitioned
+// to from the current state.
+func (sm *Micromachine[T]) ValidTransitions() []T {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	valid := make([]T, 0, len(sm.transitions[sm.state]))
+	for to := range sm.transitions[sm.state] {
+		valid = append(valid, to)
+	}
+	return valid
+}

--- a/statemachine_test.go
+++ b/statemachine_test.go
@@ -106,3 +106,57 @@ func TestStateMachine_TransitionWithError(t *testing.T) {
 		t.Errorf("expected state to remain %v, but got %v", Idle, sm.State())
 	}
 }
+
+func TestStateMachine_ValidTransitions(t *testing.T) {
+	sm := NewMicromachine(Idle)
+
+	// No transitions defined
+	transitions := sm.ValidTransitions()
+	if len(transitions) != 0 {
+		t.Errorf("expected 0 transitions, got %d", len(transitions))
+	}
+
+	// One transition
+	sm.AddTransition(Idle, Running, nil)
+	transitions = sm.ValidTransitions()
+	if len(transitions) != 1 {
+		t.Errorf("expected 1 transition, got %d", len(transitions))
+	}
+	if transitions[0] != Running {
+		t.Errorf("expected 'running' transition, got %v", transitions)
+	}
+
+	// Multiple transitions
+	sm.AddTransition(Idle, Stopped, nil)
+
+	transitions = sm.ValidTransitions()
+	if len(transitions) != 2 {
+		t.Errorf("expected 2 transitions, got %d", len(transitions))
+	}
+
+	containsRunning := false
+	containsStopped := false
+
+	for _, transition := range transitions {
+		if transition == Running {
+			containsRunning = true
+		} else if transition == Stopped {
+			containsStopped = true
+		}
+	}
+
+	if !containsRunning || !containsStopped {
+		t.Errorf("Expected transitions 'running' and 'stopped', got %v", transitions)
+	}
+
+	// Transitioning and checking again
+	err := sm.Transition(Running)
+	if err != nil {
+		t.Errorf("Failed transition: %v", err)
+	}
+
+	transitions = sm.ValidTransitions()
+	if len(transitions) != 0 {
+		t.Errorf("expected 0 transition after transitioning from idle, got %d", len(transitions))
+	}
+}


### PR DESCRIPTION
- **feat: add method to retrieve valid transitions**
- **feat: add tests for valid transitions in state machine**

- Added `ValidTransitions` method to the `Micromachine[T]` struct.
- This method returns a slice of states that can be transitioned to from
  the current state.
- The method ensures thread safety by locking the mutex during its
  execution.
- Added a new test function `TestStateMachine_ValidTransitions` to
  validate the functionality of transition states.
- The test checks the number of valid transitions when no transitions
  are defined, after adding one transition, and after adding multiple
  transitions.
- It also verifies that the state machine correctly updates its list of
  valid transitions after transitioning between states.

Closes #4
